### PR TITLE
Add test case to show we can recover from user delete

### DIFF
--- a/src/test/java/com/datastax/hectorjpa/CassandraTestBase.java
+++ b/src/test/java/com/datastax/hectorjpa/CassandraTestBase.java
@@ -184,11 +184,11 @@ public class CassandraTestBase {
     .setComparator_type(BytesType.class.getSimpleName())
     .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
     
+    cfDefList.add(new CfDef("TestKeyspace", "ParentChildEntity")
+    .setComparator_type(BytesType.class.getSimpleName())
+    .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
     
     
-    
-    
-
 
     // collection indexing
     cfDefList.add(new CfDef("TestKeyspace", AbstractCollectionField.CF_NAME)

--- a/src/test/java/com/datastax/hectorjpa/bean/ParentChildEntity.java
+++ b/src/test/java/com/datastax/hectorjpa/bean/ParentChildEntity.java
@@ -1,0 +1,5 @@
+package com.datastax.hectorjpa.bean;
+
+public class ParentChildEntity {
+
+}

--- a/src/test/java/com/datastax/hectorjpa/bean/ParentChildEntity.java
+++ b/src/test/java/com/datastax/hectorjpa/bean/ParentChildEntity.java
@@ -1,5 +1,38 @@
 package com.datastax.hectorjpa.bean;
 
-public class ParentChildEntity {
+import com.datastax.hectorjpa.annotation.ColumnFamily;
 
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+@Entity
+@ColumnFamily("ParentChildEntity")
+public class ParentChildEntity {
+  @Id
+  @GeneratedValue
+  private Long id;
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private List<ParentChildEntity> children;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public List<ParentChildEntity> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<ParentChildEntity> children) {
+    this.children = children;
+  }
 }

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -20,6 +20,7 @@
         <class>com.datastax.hectorjpa.bean.Foo2</class>
         <class>com.datastax.hectorjpa.bean.Invoice</class>
         <class>com.datastax.hectorjpa.bean.UserDateRange</class>
+        <class>com.datastax.hectorjpa.bean.ParentChildEntity</class>
 
 
         <class>com.datastax.hectorjpa.bean.inheritance.SmsMessage</class>


### PR DESCRIPTION
The test shows that there is still a problem since we will still trigger a warning from UnorderedCollectionField#readField line 85.

I can encounter this in a multi-threaded setup that features 0 deletes.  I'm just happy trunk can somewhat recover from the situation. Earlier, the returned collection was missing elements, everything after the warning was omitted.

Now, even if we save a new list to the collection field, the stale column in the index entry is still retained.